### PR TITLE
PD-6348 fix: Cannot read properties of undefined (reading 'style')

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ import {
 } from 'react-native'
 
 import PropTypes from 'prop-types';
-import { ViewPropTypes } from 'deprecated-react-native-prop-types';
+import { ViewPropTypes, TextPropTypes } from 'deprecated-react-native-prop-types';
 export const DURATION = {
     LENGTH_SHORT: 500,
     FOREVER: 0,
@@ -162,7 +162,7 @@ Toast.propTypes = {
         'center',
         'bottom',
     ]),
-    textStyle: Text.propTypes.style,
+    textStyle: TextPropTypes.style,
     positionValue:PropTypes.number,
     fadeInDuration:PropTypes.number,
     fadeOutDuration:PropTypes.number,


### PR DESCRIPTION
[PD-6348]

[Problem]
<img width="568" alt="스크린샷 2023-10-16 오전 10 54 05" src="https://github.com/team-olulo/react-native-easy-toast/assets/85471652/d74d8dfe-e8b9-44ae-a78b-dd7c7af81687">

[Solution]
```textStyle: TextPropTypes.style,```

https://www.youtube.com/watch?v=DHHvSXQzHLk

킥고잉 2.9.4 실행 확인함

[PD-6348]: https://olulo.atlassian.net/browse/PD-6348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ